### PR TITLE
feat: Implement Main Dashboard and Notebook Workspace navigation

### DIFF
--- a/frontend/src/components/Dashboard.css
+++ b/frontend/src/components/Dashboard.css
@@ -1,0 +1,303 @@
+/* General Dashboard Container */
+.dashboard-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh; /* Full viewport height */
+  background-color: #f8f9fa; /* Light background for the dashboard area */
+}
+
+.dashboard-main-content {
+  flex-grow: 1;
+  padding: 24px 48px; /* More padding for a spacious feel */
+  overflow-y: auto;
+}
+
+/* Welcome Area */
+.dashboard-welcome-area {
+  text-align: center;
+  margin-bottom: 40px; /* Increased spacing */
+  padding-top: 20px;
+}
+
+.dashboard-welcome-area h1 {
+  font-size: 2.8em; /* Larger welcome message */
+  font-weight: 600; /* Semi-bold */
+  color: #212529; /* Darker text */
+  margin-bottom: 24px;
+}
+
+.dashboard-create-new-button {
+  background-color: #000000; /* Black button */
+  color: #ffffff;
+  border: none;
+  padding: 14px 28px; /* Larger padding */
+  border-radius: 50px; /* Pill shape */
+  font-size: 1.1em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dashboard-create-new-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.dashboard-create-new-button .plus-icon {
+  font-size: 1.4em;
+  font-weight: bold;
+}
+
+/* List Area Toolbar */
+.dashboard-list-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding: 10px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.view-toggle {
+  display: flex;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  overflow: hidden; /* Ensures rounded corners apply to children */
+}
+
+.view-button {
+  background-color: #fff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: #495057;
+  transition: background-color 0.2s;
+}
+
+.view-button:not(:last-child) {
+  border-right: 1px solid #dee2e6;
+}
+
+.view-button.active {
+  background-color: #007bff; /* Blue for active */
+  color: white;
+}
+
+.view-button:hover:not(.active) {
+  background-color: #e9ecef;
+}
+
+.view-button .material-symbols-outlined {
+  display: block; /* Ensure icon is block for proper alignment/sizing */
+  font-size: 20px; /* Adjust icon size */
+}
+
+
+.sort-dropdown .dashboard-select {
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid #ced4da;
+  background-color: #fff;
+  color: #495057;
+  font-size: 0.9em;
+}
+
+/* Notebook Table (List View) */
+.dashboard-notebook-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+  overflow: hidden; /* For rounded corners on table */
+}
+
+.dashboard-notebook-table th,
+.dashboard-notebook-table td {
+  padding: 16px 20px; /* More padding in cells */
+  text-align: left;
+  border-bottom: 1px solid #e9ecef; /* Lighter border for rows */
+}
+
+.dashboard-notebook-table th {
+  background-color: #f8f9fa; /* Very light grey for header */
+  font-weight: 500; /* Medium weight for headers */
+  color: #6c757d; /* Grey text for headers */
+  font-size: 0.9em;
+  text-transform: uppercase; /* As per PRD example */
+}
+
+.dashboard-notebook-table tbody tr:hover {
+  background-color: #f1f3f5; /* Hover effect for rows */
+}
+
+.notebook-title-cell {
+  font-weight: 500;
+  color: #007bff; /* Blue for clickable titles */
+  cursor: pointer;
+}
+
+.notebook-title-cell:hover {
+  text-decoration: underline;
+}
+
+.rename-input {
+  padding: 6px 8px;
+  border: 1px solid #007bff;
+  border-radius: 4px;
+  font-size: 1em;
+  width: calc(100% - 16px); /* Adjust width to fit cell */
+}
+
+/* Kebab menu and dropdown */
+.notebook-actions-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.kebab-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 5px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.kebab-button:hover {
+  background-color: #e0e0e0;
+}
+
+.kebab-button .material-symbols-outlined {
+  font-size: 20px;
+  color: #555;
+}
+
+.actions-dropdown {
+  display: none; /* Hidden by default */
+  position: absolute;
+  right: 0;
+  top: 100%; /* Position below the button */
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  z-index: 10;
+  min-width: 150px; /* Minimum width for dropdown */
+  padding: 5px 0;
+}
+
+.actions-dropdown.show {
+  display: block;
+}
+
+.actions-dropdown button {
+  display: block;
+  width: 100%;
+  padding: 10px 15px;
+  text-align: left;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.9em;
+  color: #333;
+}
+
+.actions-dropdown button:hover {
+  background-color: #f5f5f5;
+}
+
+
+/* Empty State */
+.dashboard-empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: #6c757d; /* Softer text color for empty state */
+}
+
+.dashboard-empty-state p {
+  font-size: 1.1em;
+  margin-bottom: 8px;
+}
+
+.dashboard-no-results {
+  text-align: center;
+  padding: 40px 20px;
+  color: #6c757d;
+  font-size: 1.1em;
+}
+
+/* Grid View */
+.dashboard-notebook-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); /* Responsive grid */
+  gap: 24px; /* Gap between grid items */
+  padding-top: 10px;
+}
+
+.grid-item {
+  background-color: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.grid-item:hover {
+  box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+  transform: translateY(-3px);
+}
+
+.grid-item h3 {
+  font-size: 1.3em;
+  color: #333;
+  margin-top: 0;
+  margin-bottom: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.grid-item p {
+  font-size: 0.9em;
+  color: #555;
+  margin-bottom: 8px;
+}
+
+.grid-item-actions {
+  margin-top: 15px;
+  border-top: 1px solid #f0f0f0;
+  padding-top: 10px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.grid-item-actions button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em; /* Larger icons for grid actions */
+  color: #6c757d;
+}
+
+.grid-item-actions button:hover {
+  color: #007bff;
+}
+
+/* Ensure material icons are available */
+.material-symbols-outlined {
+  font-variation-settings:
+  'FILL' 0,
+  'wght' 400,
+  'GRAD' 0,
+  'opsz' 24
+}

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,52 +1,237 @@
 import React, { useState, useEffect } from 'react';
-import { getNotebooks, addNotebook } from '../utils/localStorageHelper';
+import Header from './Header'; // Import Header
+import './Dashboard.css'; // We will create this file
 
-function Dashboard({ onNavigateToNotebook }) { // Accept onNavigateToNotebook as a prop
-    const [notebooks, setNotebooks] = useState([]);
+// Helper to format date as "YYYY年M月D日"
+const formatDate = (isoString) => {
+    if (!isoString) return 'N/A';
+    const date = new Date(isoString);
+    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+};
 
-    useEffect(() => {
-        setNotebooks(getNotebooks());
-    }, []);
 
-    const handleCreateNotebook = () => {
-        const newNotebook = {
-            id: Date.now(), // Simple unique ID
-            title: `Untitled notebook ${notebooks.length + 1}`,
-            createdAt: new Date().toISOString(),
-            sources: [] // To store summaries later
-        };
-        const updatedNotebooks = addNotebook(newNotebook);
-        setNotebooks(updatedNotebooks);
-        // Optionally, navigate to the new notebook immediately
-        if (onNavigateToNotebook) {
-            onNavigateToNotebook(newNotebook.id);
+function Dashboard({ notebooks, onNavigateToNotebook, onCreateNotebook, onEditNotebookTitle, onDeleteNotebook }) {
+    const [searchTerm, setSearchTerm] = useState(''); // For future search functionality
+    const [sortOption, setSortOption] = useState('recent'); // Default sort: 'recent', 'nameAsc', 'nameDesc', 'createdAsc', 'createdDesc'
+    const [viewMode, setViewMode] = useState('list'); // 'list' or 'grid'
+    const [editingNotebookId, setEditingNotebookId] = useState(null); // For inline rename
+    const [renameTitle, setRenameTitle] = useState(''); // For inline rename input
+
+    // Filter and Sort Notebooks
+    const processedNotebooks = notebooks
+        .filter(notebook => notebook.title.toLowerCase().includes(searchTerm.toLowerCase()))
+        .sort((a, b) => {
+            switch (sortOption) {
+                case 'nameAsc':
+                    return a.title.localeCompare(b.title);
+                case 'nameDesc':
+                    return b.title.localeCompare(a.title);
+                case 'createdAsc':
+                    return new Date(a.createdAt) - new Date(b.createdAt);
+                case 'createdDesc':
+                case 'recent': // Default to recent (createdDesc)
+                default:
+                    return new Date(b.createdAt) - new Date(a.createdAt);
+            }
+        });
+
+    const handleCreateAndNavigate = () => {
+        // Default title as per PRD
+        const newNotebookId = onCreateNotebook("未命名笔记本");
+        // Navigation to workspace is handled in App.js after selectedNotebookId is set
+    };
+
+    const startRename = (notebook) => {
+        setEditingNotebookId(notebook.id);
+        setRenameTitle(notebook.title);
+    };
+
+    const cancelRename = () => {
+        setEditingNotebookId(null);
+        setRenameTitle('');
+    };
+
+    const submitRename = () => {
+        if (editingNotebookId && renameTitle.trim() !== '') {
+            onEditNotebookTitle(editingNotebookId, renameTitle.trim()); // Pass ID and new title
+        }
+        cancelRename();
+    };
+
+    const handleRenameKeyPress = (event) => {
+        if (event.key === 'Enter') {
+            submitRename();
+        } else if (event.key === 'Escape') {
+            cancelRename();
         }
     };
 
+    // Placeholder for duplicate
+    const handleDuplicateNotebook = (notebookId) => {
+        const notebookToDuplicate = notebooks.find(nb => nb.id === notebookId);
+        if (notebookToDuplicate) {
+            // Create a new title for the duplicate
+            const duplicateTitle = `${notebookToDuplicate.title} 的副本`;
+            // Create the new notebook object
+            const newNotebook = {
+                // id: Date.now(), // Handled by onCreateNotebook or similar logic in App.js
+                title: duplicateTitle,
+                // createdAt: new Date().toISOString(), // Handled by onCreateNotebook
+                sources: notebookToDuplicate.sources.map(source => ({ ...source, id: Date.now() + Math.random() })), // Deep copy sources with new IDs
+                chatHistory: notebookToDuplicate.chatHistory ? notebookToDuplicate.chatHistory.map(entry => ({...entry})) : [] // Deep copy chat history
+            };
+            // Call App.js function to actually add it. This function needs to be created or adapted in App.js
+            // For now, let's assume onCreateNotebook can take a full notebook object or specific parts.
+            // This part needs careful implementation in App.js.
+            // Let's simplify for now: App.js's handleCreateNewNotebook already creates a new notebook.
+            // We'll need a new function in App.js like `handleDuplicateExistingNotebook(notebookToDuplicate)`
+
+            // Simplified: use onCreateNotebook and then update it. This is not ideal.
+            // A dedicated duplication function in App.js is better.
+            // For this step, we'll just log it.
+            console.log("Attempting to duplicate notebook:", notebookToDuplicate.title, "as", duplicateTitle);
+            alert(`Duplicating "${notebookToDuplicate.title}" - (Full implementation requires App.js changes)`);
+
+            // Ideal flow:
+            // const duplicatedNotebookId = onDuplicateNotebook(notebookId); // This function would live in App.js
+            // if (duplicatedNotebookId) {
+            //   console.log("Notebook duplicated with ID:", duplicatedNotebookId);
+            // }
+        }
+    };
+
+
+    const handleDeleteWithConfirmation = (notebookId, notebookTitle) => {
+        if (window.confirm(`您确定要永久删除 ‘${notebookTitle}’ 吗？此操作无法撤销。`)) {
+            onDeleteNotebook(notebookId);
+        }
+    };
+
+
+    // Empty State Content
+    const EmptyState = () => (
+        <div className="dashboard-empty-state">
+            <span role="img" aria-label="empty-notebooks" style={{fontSize: '4em', marginBottom: '20px'}}>🗂️</span>
+            <p>您的知识库空空如也。</p>
+            <p>点击‘新建’，开始整理您的第一个项目吧！</p>
+        </div>
+    );
+
     return (
-        <div>
-            <h2>Dashboard</h2>
-            <button onClick={handleCreateNotebook} style={{ marginBottom: '20px' }}>
-                Create New Notebook
-            </button>
-            <h3>My Notebooks:</h3>
-            {notebooks.length === 0 ? (
-                <p>No notebooks yet. Create one to get started!</p>
-            ) : (
-                <ul style={{ listStyle: 'none', padding: 0 }}>
-                    {notebooks.map((notebook) => (
-                        <li key={notebook.id} style={{ marginBottom: '10px' }}>
+        <div className="dashboard-container">
+            <Header onNavigateToDashboard={() => onNavigateToNotebook(null)} /> {/* Clicking logo goes to dashboard (clears selection) */}
+
+            <div className="dashboard-main-content">
+                <div className="dashboard-welcome-area">
+                    <h1>欢迎使用 NotebookLM</h1>
+                    <button onClick={handleCreateAndNavigate} className="dashboard-create-new-button">
+                        <span className="plus-icon">+</span> 新建
+                    </button>
+                </div>
+
+                <div className="dashboard-list-area">
+                    <div className="dashboard-list-toolbar">
+                        <div className="view-toggle">
                             <button
-                                onClick={() => onNavigateToNotebook && onNavigateToNotebook(notebook.id)}
-                                style={{ background: 'none', border: 'none', color: 'blue', textDecoration: 'underline', cursor: 'pointer', padding: '5px', textAlign: 'left' }}
+                                className={`view-button ${viewMode === 'list' ? 'active' : ''}`}
+                                onClick={() => setViewMode('list')}
+                                title="List view"
                             >
-                                {notebook.title}
+                                <span className="material-symbols-outlined">list</span>
                             </button>
-                            <p style={{fontSize: '0.8em', color: 'gray'}}>Created: {new Date(notebook.createdAt).toLocaleDateString()}</p>
-                        </li>
-                    ))}
-                </ul>
-            )}
+                            <button
+                                className={`view-button ${viewMode === 'grid' ? 'active' : ''}`}
+                                onClick={() => setViewMode('grid')}
+                                title="Grid view"
+                            >
+                                <span className="material-symbols-outlined">grid_view</span>
+                            </button>
+                        </div>
+                        {/* Placeholder for search: <input type="text" placeholder="Search notebooks..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} /> */}
+                        <div className="sort-dropdown">
+                            <select value={sortOption} onChange={(e) => setSortOption(e.target.value)} className="dashboard-select">
+                                <option value="recent">最近修改</option>
+                                <option value="createdDesc">创建时间 (从新到旧)</option>
+                                <option value="createdAsc">创建时间 (从旧到新)</option>
+                                <option value="nameAsc">名称 (A-Z)</option>
+                                <option value="nameDesc">名称 (Z-A)</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    {processedNotebooks.length === 0 && !searchTerm ? (
+                        <EmptyState />
+                    ) : processedNotebooks.length === 0 && searchTerm ? (
+                        <p className="dashboard-no-results">No notebooks found for "{searchTerm}".</p>
+                    ) : (
+                        viewMode === 'list' ? (
+                            <table className="dashboard-notebook-table">
+                                <thead>
+                                    <tr>
+                                        <th>标题</th>
+                                        <th>来源数量</th>
+                                        <th>创建时间</th>
+                                        <th>角色</th>
+                                        <th>操作</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {processedNotebooks.map((notebook) => (
+                                        <tr key={notebook.id} onDoubleClick={() => onNavigateToNotebook(notebook.id)}>
+                                            <td onClick={() => onNavigateToNotebook(notebook.id)} className="notebook-title-cell">
+                                                {editingNotebookId === notebook.id ? (
+                                                    <input
+                                                        type="text"
+                                                        value={renameTitle}
+                                                        onChange={(e) => setRenameTitle(e.target.value)}
+                                                        onBlur={submitRename}
+                                                        onKeyPress={handleRenameKeyPress}
+                                                        autoFocus
+                                                        className="rename-input"
+                                                    />
+                                                ) : (
+                                                    notebook.title
+                                                )}
+                                            </td>
+                                            <td>{notebook.sources?.length || 0} 个来源</td>
+                                            <td>{formatDate(notebook.createdAt)}</td>
+                                            <td>Owner</td> {/* Placeholder as per PRD */}
+                                            <td>
+                                                <div className="notebook-actions-menu">
+                                                    <button className="kebab-button" onClick={(e) => e.currentTarget.nextElementSibling.classList.toggle('show')}>
+                                                        <span className="material-symbols-outlined">more_vert</span>
+                                                    </button>
+                                                    <div className="actions-dropdown">
+                                                        <button onClick={() => startRename(notebook)}>重命名</button>
+                                                        <button onClick={() => handleDuplicateNotebook(notebook.id)}>创建副本</button>
+                                                        <button onClick={() => handleDeleteWithConfirmation(notebook.id, notebook.title)}>删除</button>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        ) : (
+                            // Grid View (Basic Placeholder)
+                            <div className="dashboard-notebook-grid">
+                                {processedNotebooks.map((notebook) => (
+                                   <div key={notebook.id} className="grid-item" onClick={() => onNavigateToNotebook(notebook.id)}>
+                                        <h3>{notebook.title}</h3>
+                                        <p>{notebook.sources?.length || 0} 个来源</p>
+                                        <p>Created: {formatDate(notebook.createdAt)}</p>
+                                        {/* Simplified actions for grid view for now */}
+                                        <div className="grid-item-actions">
+                                            <button onClick={(e) => { e.stopPropagation(); startRename(notebook);}} title="Rename">✏️</button>
+                                            <button onClick={(e) => { e.stopPropagation(); handleDeleteWithConfirmation(notebook.id, notebook.title);}} title="Delete">🗑️</button>
+                                        </div>
+                                   </div>
+                                ))}
+                            </div>
+                        )
+                    )}
+                </div>
+            </div>
         </div>
     );
 }

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -1,0 +1,75 @@
+.header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 24px;
+  border-bottom: 1px solid #e0e0e0; /* Light grey border */
+  background-color: #ffffff; /* White background */
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.header-logo {
+  font-size: 1.5em; /* Larger font for logo */
+  font-weight: bold;
+  color: #333; /* Dark grey text */
+  display: flex;
+  align-items: center;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px; /* Space between action items */
+}
+
+.header-button {
+  background-color: #fff;
+  color: #555; /* Slightly lighter text for buttons */
+  border: 1px solid #ccc; /* Light grey border */
+  padding: 8px 12px;
+  border-radius: 20px; /* Pill-shaped buttons */
+  cursor: pointer;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.header-button:hover {
+  background-color: #f5f5f5; /* Slight hover effect */
+}
+
+.header-button.app-switcher {
+  padding: 8px; /* Make it more square-like */
+}
+
+.header-pro-tag {
+  background-color: #f0f0f0; /* Light grey background for PRO tag */
+  color: #555;
+  padding: 6px 10px;
+  border-radius: 16px; /* Rounded corners */
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.header-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%; /* Circular avatar */
+  background-color: #e0e0e0; /* Placeholder background */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  /* Example gradient border from PRD */
+  border: 2px solid;
+  border-image-slice: 1;
+  border-image-source: conic-gradient(from 0deg, red, orange, yellow, green, blue, indigo, violet, red);
+  overflow: hidden; /* In case image is used */
+}
+
+.header-avatar span { /* For emoji placeholder */
+  font-size: 1.8em;
+}

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import './Header.css'; // We will create this file next
+
+const Header = ({ onNavigateToDashboard }) => {
+  return (
+    <div className="header-bar">
+      <div className="header-logo" onClick={onNavigateToDashboard} style={{ cursor: 'pointer' }}>
+        {/* Placeholder for actual logo icon */}
+        <span role="img" aria-label="logo-icon" style={{ marginRight: '8px', fontSize: '1.5em' }}>📚</span>
+        NotebookLM
+      </div>
+      <div className="header-actions">
+        {/* Placeholders for right-side elements */}
+        <button className="header-button">设置</button>
+        <span className="header-pro-tag">PRO</span>
+        <button className="header-button app-switcher">
+          {/* Placeholder for 3x3 dot icon */}
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+            <circle cx="6" cy="6" r="2"/>
+            <circle cx="12" cy="6" r="2"/>
+            <circle cx="18" cy="6" r="2"/>
+            <circle cx="6" cy="12" r="2"/>
+            <circle cx="12" cy="12" r="2"/>
+            <circle cx="18" cy="12" r="2"/>
+            <circle cx="6" cy="18" r="2"/>
+            <circle cx="12" cy="18" r="2"/>
+            <circle cx="18" cy="18" r="2"/>
+          </svg>
+        </button>
+        <div className="header-avatar">
+          {/* Placeholder for avatar - e.g., an astronaut */}
+          <span role="img" aria-label="user-avatar" style={{ fontSize: '1.8em' }}>🧑‍🚀</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -15,6 +15,7 @@ const Sidebar = ({
     onDeleteNotebook,
     onToggleWebsiteSummarizer, // Changed from onToggleYoutubeSummarizer
     onToggleTextFileSummarizer, // New prop
+    onNavigateToDashboard, // New prop to go back to dashboard
 }) => {
     // const [showYoutubeSummarizer, setShowYoutubeSummarizer] = useState(false); // Removed
     // const [showTextFileSummarizer, setShowTextFileSummarizer] = useState(false); // Removed
@@ -41,6 +42,16 @@ const Sidebar = ({
 
     return (
         <div className="sidebar">
+            {/* Simple way to navigate back to Dashboard from Sidebar */}
+            <button
+                onClick={onNavigateToDashboard}
+                className="action"
+                style={{ width: '100%', marginBottom: 'var(--spacing-md)', backgroundColor: 'var(--color-background-secondary)' }}
+            >
+                <span className="material-symbols-outlined" style={{ marginRight: 'var(--spacing-sm)'}}>arrow_back</span>
+                Back to Dashboard
+            </button>
+
             <h2>Notebooks</h2>
             <button
                 onClick={onAddNotebook}
@@ -89,15 +100,15 @@ const Sidebar = ({
             <hr className="sidebar-section-separator" />
 
             {selectedNotebook && (
-                <div style={{ marginTop: '20px' }}>
+                <div style={{ marginTop: 'var(--spacing-lg)' }}> {/* Consistent spacing */}
                     {/* Add Source Buttons */}
-                    <div className="add-source-buttons-sidebar" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-md)', marginBottom: 'var(--spacing-xl)' }}>
+                    <div className="add-source-buttons-sidebar" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-md)', marginBottom: 'var(--spacing-lg)' }}> {/* Consistent spacing */}
                         <button onClick={() => onToggleWebsiteSummarizer(true)} className="action icon-button"> {/* Changed from primary to action */}
-                            <span className="material-symbols-outlined" style={{ marginRight: 'var(--spacing-sm)'}}>add_link</span>
+                            <span className="material-symbols-outlined" style={{ marginRight: 'var(--spacing-sm)' }}>add_link</span>
                             Add Website Source
                         </button>
                         <button onClick={() => onToggleTextFileSummarizer(true)} className="action icon-button"> {/* Changed from primary to action */}
-                            <span className="material-symbols-outlined" style={{ marginRight: 'var(--spacing-sm)'}}>note_add</span>
+                            <span className="material-symbols-outlined" style={{ marginRight: 'var(--spacing-sm)' }}>note_add</span>
                             Add File Source
                         </button>
                     </div>


### PR DESCRIPTION
Introduces a main dashboard as the application entry point, allowing users to view, create, rename, and delete notebooks.

Key changes:
- App.js refactored to manage two primary views: 'dashboard' and 'notebookWorkspace'.
- New Dashboard.js component created with:
  - Header (Logo, placeholder action buttons).
  - Welcome message and 'Create New' button.
  - Notebook list with List/Grid views and sorting.
  - Actions for notebooks (Rename, Delete, Duplicate (placeholder)).
- Sidebar.js in workspace view now includes a 'Back to Dashboard' button.
- Core navigation flow between dashboard and workspace implemented.
- Styling applied as per PRD V2.0 for dashboard and header elements.